### PR TITLE
[ADD]Delete message

### DIFF
--- a/app.py
+++ b/app.py
@@ -97,33 +97,34 @@ def userSignup():
 
 
 
-############
-# Message  #
-############
+###########
+# Message #
+###########
 @app.post('/message')
-def add_message():
-    print("Add Message!!!")
+def message():
     uid = session.get("uid")
     if uid is None:
         return redirect('/login')
-
-    message = request.form.get('add_message')
-    print('message = ',message)
+    
     # channel_id = request.form.get('channel_id')
     cid = 1
     name = session.get('username')
 
-    if message:
-        dbConnect.createMessage(uid, cid, message)
+    if request.form.get('_method') == 'DELETE':
+        # DELETEリクエストの処理
+        print("Delete Message!!!")
+        mid = request.form.get('message_id')
+        dbConnect.deleteMessage(mid)
+    else:
+        print("Add Message!!!")
+        message = request.form.get('add_message')
+        print('message = ',message)
+        if message:
+            dbConnect.createMessage(uid, cid, message)
     
     channel = dbConnect.getChannelById(cid)
     messages = dbConnect.getMessageAll(cid)
-
     return render_template('index.html', messages=messages, channel=channel, uid=uid, username=name)
-
-
-
-
 
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -29,14 +29,16 @@
                 <p class="user-name own">{{ message.user_name }}</p>
                 <div class="my-messages-wrapper">
                   <p class="box box-right">{{ message.message }}</p>
-                  <form id="delete-message" name="delete-message" action="/delete_message" method="POST">
-                    <input type="hidden" value="{{ channel.id }}" name="channel_id" />
+                  <form id="delete-message" name="delete-message" action="/message" method="POST">
+                    <input type="hidden" name="_method" value="DELETE">
+                    <!-- <input type="hidden" value="{{ channel }}" name="channel_id" /> -->
                     <button
                       class="delete-message-btn"
                       name="message_id"
                       value="{{ message.id }}"
                     >
-                      <ion-icon name="trash-bin-outline"></ion-icon>
+                      X
+                      <!-- <ion-icon name="trash-bin-outline"></ion-icon> -->
                     </button>
                   </form>
               </div>


### PR DESCRIPTION
メッセージ削除機能追加。
同一URI (’/message’)にDELETEメソッドで処理を試みたが、現在のブラウザはformタグにDELETEメソッドをサポートしていないため、実現できなかった。代わりにPOSTメソッドでメッセージ投稿機能と同一URIにアクセスし隠し要素にDELETEを渡し条件分岐で対応することにした。
